### PR TITLE
fix: add support for getting initial value from slotted fields

### DIFF
--- a/src/vaadin-date-time-picker.html
+++ b/src/vaadin-date-time-picker.html
@@ -22,7 +22,7 @@ This program is available under Apache License Version 2.0, available at https:/
         display: none !important;
       }
     </style>
-    <vaadin-custom-field id="customField" on-value-changed="__customFieldValueChanged" theme$="[[theme]]">
+    <vaadin-custom-field id="customField" on-value-changed="__customFieldValueChanged" i18n="[[__customFieldValueFormat]]" theme$="[[theme]]">
       <slot name="date-picker">
         <vaadin-date-picker part="date" theme$="[[theme]]"></vaadin-date-picker>
       </slot>
@@ -112,6 +112,14 @@ This program is available under Apache License Version 2.0, available at https:/
             __selectedDateTime: {
               type: Date
             },
+
+            __customFieldValueFormat: {
+              type: Object,
+              value: () => ({
+                parseValue: combinedValue => combinedValue.split('T'),
+                formatValue: inputValues => inputValues.join('T')
+              })
+            }
           };
         }
 
@@ -258,7 +266,25 @@ This program is available under Apache License Version 2.0, available at https:/
             this.value = formattedValue;
           }
 
-          this.$.customField.value = formattedValue;
+          // Setting the customField.value below triggers validation of the date picker and time picker.
+          // If the inputs are slotted (e.g. when using the Java API) and have an initial value this can
+          // happen before date picker ready() which triggers an error when date picker is trying to read
+          // `this.$.input` (as a result of value change triggered by setting custom field value).
+          // Workaround the problem by overriding customField.validate while setting the initial value.
+          if (!this.$.customField.inputs[0].$) {
+            const validate = this.$.customField.validate;
+            /* istanbul ignore next */
+            this.$.customField.validate = () => true;
+
+            this.$.customField.value = this.value;
+
+            this.$.customField.validate = validate;
+            setTimeout(() => {
+              this.$.customField.validate();
+            });
+          } else {
+            this.$.customField.value = this.value;
+          }
         }
 
         __customFieldValueChanged(e) {
@@ -269,13 +295,9 @@ This program is available under Apache License Version 2.0, available at https:/
             return;
           }
 
-          // Initial empty value ('\t') from custom field
-          if (value === '\t') {
-            // Set value format for custom field
-            /* istanbul ignore next */
-            this.$.customField.set('i18n.parseValue', combinedValue => combinedValue.split('T'));
-            /* istanbul ignore next */
-            this.$.customField.set('i18n.formatValue', inputValues => inputValues.join('T'));
+          // Initial empty value from custom field
+          if (value === 'T' && !this.__customFieldInitialValueChangeReceived) {
+            this.__customFieldInitialValueChangeReceived = true;
             // Ignore initial value from custom field so we don't override initial value of date time picker
             return;
           }

--- a/test/basic.html
+++ b/test/basic.html
@@ -37,6 +37,15 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="slotted-values">
+    <template>
+      <vaadin-date-time-picker>
+        <vaadin-date-picker slot="date-picker" value="2019-09-16"></vaadin-date-picker>
+        <vaadin-time-picker slot="time-picker" value="15:00"></vaadin-time-picker>
+      </vaadin-date-time-picker>
+    </template>
+  </test-fixture>
+
   <script>
     describe('Basic features', () => {
       let dateTimePicker;
@@ -142,7 +151,7 @@
 
       it('should use initial value from attribute without clearing it', () => {
         expect(dateTimePicker.value).to.equal('2019-09-16T15:00');
-        expect(customField.value).to.equal('2019-09-16T15:00:00.000');
+        expect(customField.value).to.equal('2019-09-16T15:00');
       });
 
     });
@@ -208,6 +217,26 @@
         datePicker.value = '2019-09-16';
         timePicker.value = '15:00';
         customField.__setValue();
+        expect(dateTimePicker.value).to.equal('2019-09-16T15:00');
+      });
+
+    });
+
+    describe('Initial value from slotted inputs', () => {
+      let dateTimePicker;
+      let customField;
+
+      beforeEach(() => {
+        dateTimePicker = fixture('slotted-values');
+        customField = dateTimePicker.$.customField;
+        if (window.ShadyDOM) {
+          window.ShadyDOM.flush();
+        }
+      });
+
+      // This test simulates how DatePicker sets the initial value from server side
+      it('should get initial value from slotted inputs', () => {
+        expect(customField.value).to.equal('2019-09-16T15:00');
         expect(dateTimePicker.value).to.equal('2019-09-16T15:00');
       });
 


### PR DESCRIPTION
Additionally:
- Set custom field value format methods earlier (via data binding) so that the first `value-changed` event from custom field already uses the correct format (with 'T' instead of '\t')
- When setting custom field value from date time picker, use `this.value` instead of `formattedValue` for more consistent formatting (to avoid unnecessarily adding `:00.000` or `.000` to end of time in more cases until we have support for `step` property which should handle this better)

Fixes #11.