### PR TITLE
feat: implement focus() and autofocus

### DIFF
--- a/src/vaadin-date-time-picker.html
+++ b/src/vaadin-date-time-picker.html
@@ -106,9 +106,16 @@ This program is available under Apache License Version 2.0, available at https:/
        * The following shadow DOM parts are available for styling:
        *
        * Part name | Description | Theme for Element
-       * ----------------|----------------|----------------
+       * ----------|-------------|------------------
        * `date` | Date picker element | vaadin-date-time-picker
        * `time` | Time picker element | vaadin-date-time-picker
+       *
+       * The following state attributes are available for styling:
+       *
+       * Attribute | Description | Part name
+       * ----------|-------------|----------
+       * `disabled` | Set when the element is disabled | :host
+       * `readonly` | Set when the element is read-only | :host
        *
        * See [ThemableMixin – Stylable Shadow Parts](https://github.com/vaadin/vaadin-themable-mixin#stylable-shadow-parts)
        *
@@ -282,6 +289,13 @@ This program is available under Apache License Version 2.0, available at https:/
             },
 
             /**
+             * Specify that this control should have input focus when the page loads.
+             */
+            autofocus: {
+              type: Boolean
+            },
+
+            /**
              * The current selected date time.
              */
             __selectedDateTime: {
@@ -347,6 +361,17 @@ This program is available under Apache License Version 2.0, available at https:/
 
           this.$.dateSlot.addEventListener('slotchange', this.__datePickerChanged.bind(this));
           this.$.timeSlot.addEventListener('slotchange', this.__timePickerChanged.bind(this));
+
+          if (this.autofocus && !this.disabled) {
+            window.requestAnimationFrame(() => this.focus());
+          }
+        }
+
+        /**
+         * @private
+         */
+        focus() {
+          this.$.customField.focus();
         }
 
         __syncI18n(target, source, props) {

--- a/test/basic.html
+++ b/test/basic.html
@@ -64,6 +64,12 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="autofocus">
+    <template>
+      <vaadin-date-time-picker autofocus></vaadin-date-time-picker>
+    </template>
+  </test-fixture>
+
   <script>
     function changeInputValue(el, value) {
       el.value = value;
@@ -121,6 +127,20 @@
         timePicker.value = '15:00';
         dateTimePicker.__triggerCustomFieldValueUpdate();
         expect(dateTimePicker.value).to.equal('2019-09-19T15:00');
+      });
+
+      it('should delegate focus() to date picker', () => {
+        dateTimePicker.focus();
+        expect(datePicker.hasAttribute('focused')).to.be.true;
+      });
+
+      it('should focus date picker when autofocus is set', done => {
+        dateTimePicker = fixture('autofocus');
+        datePicker = dateTimePicker.__datePicker;
+        requestAnimationFrame(() => {
+          expect(datePicker.hasAttribute('focused')).to.be.true;
+          done();
+        });
       });
 
       describe('change event', () => {


### PR DESCRIPTION
Fixes #24.

Related to vaadin/vaadin-date-time-picker-flow#5.

This also includes a small documentation update unrelated to the issue (documenting state attributes `disabled` and `readonly` that were implemented in #18)