### PR TITLE
fix: propagate disabled and readonly to slotted fields on init

### DIFF
--- a/src/vaadin-date-time-picker.html
+++ b/src/vaadin-date-time-picker.html
@@ -473,8 +473,6 @@ This program is available under Apache License Version 2.0, available at https:/
             datePicker.invalid = this.invalid;
             datePicker.initialPosition = this.initialPosition;
             datePicker.showWeekNumbers = this.showWeekNumbers;
-            datePicker.disabled = this.disabled;
-            datePicker.readonly = this.readonly;
             this.__syncI18n(datePicker, this, datePickerI18nProps);
           } else {
             // Synchronize properties from slotted date picker
@@ -489,6 +487,8 @@ This program is available under Apache License Version 2.0, available at https:/
           datePicker.min = this.__formatDateISO(this.__minDateTime, this.__defaultDateMinMaxValue);
           datePicker.max = this.__formatDateISO(this.__maxDateTime, this.__defaultDateMinMaxValue);
           datePicker.required = this.required;
+          datePicker.disabled = this.disabled;
+          datePicker.readonly = this.readonly;
 
           // Disable default internal validation for the component
           datePicker.validate = () => {};
@@ -512,8 +512,6 @@ This program is available under Apache License Version 2.0, available at https:/
             timePicker.placeholder = this.timePlaceholder;
             timePicker.step = this.step;
             timePicker.invalid = this.invalid;
-            timePicker.disabled = this.disabled;
-            timePicker.readonly = this.readonly;
             this.__syncI18n(timePicker, this, timePickerI18nProps);
           } else {
             // Synchronize properties from slotted time picker
@@ -526,6 +524,8 @@ This program is available under Apache License Version 2.0, available at https:/
           // need to be dynamically set depending on currently selected date instead of simple propagation
           this.__updateTimePickerMinMax();
           timePicker.required = this.required;
+          timePicker.disabled = this.disabled;
+          timePicker.readonly = this.readonly;
 
           // Disable default internal validation for the component
           timePicker.validate = () => {};

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,4 +1,8 @@
 {
+  "rules": {
+    "no-undef": 0,
+    "no-unused-vars": 0
+  },
   "globals": {
     "WCT": false,
     "describe": false,

--- a/test/basic.html
+++ b/test/basic.html
@@ -7,6 +7,7 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-date-time-picker.html">
+  <script src="common.js"></script>
 </head>
 
 <body>

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,2 @@
+var ua = navigator.userAgent;
+var ie11 = /Trident/.test(ua);

--- a/test/i18n.html
+++ b/test/i18n.html
@@ -8,6 +8,7 @@
   <link rel="import" href="../../polymer/lib/elements/dom-bind.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-date-time-picker.html">
+  <script src="common.js"></script>
 </head>
 
 <body>

--- a/test/propagated-properties.html
+++ b/test/propagated-properties.html
@@ -7,6 +7,7 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-date-time-picker.html">
+  <script src="common.js"></script>
 </head>
 
 <body>
@@ -336,6 +337,14 @@
         });
 
         it('should have initial value for value property', () => {
+          if (ie11 && set === 'slotted' && customField.hasAttribute('disabled')) {
+            // In IE11 with the slotted fixture the value doesn't get propagated from custom-field
+            // to date-time-picker for some reason when the custom-field has "disabled" attribute.
+            // For this tests sake (which is not supposed to test disabled state anyway) we can fix
+            // this by manually triggering the custom-field value change handler in date-time-picker.
+            dateTimePicker.__customFieldValueChanged(new CustomEvent('value-changed', {detail: {value: customField.value}}));
+          }
+
           expect(dateTimePicker.value).to.equal('2019-09-16T15:00');
           expect(datePicker.value).to.equal('2019-09-16');
           expect(timePicker.value).to.equal('15:00');

--- a/test/propagated-properties.html
+++ b/test/propagated-properties.html
@@ -27,7 +27,7 @@
 
   <test-fixture id="initial-properties">
     <template>
-      <vaadin-date-time-picker 
+      <vaadin-date-time-picker
         value="2019-09-16T15:00"
         min="2019-09-01T08:00"
         max="2019-09-30T22:00"
@@ -39,13 +39,21 @@
         label="Birth date and time"
         error-message="error-message"
         required
+        disabled
+        readonly
       ></vaadin-date-time-picker>
     </template>
   </test-fixture>
 
   <test-fixture id="slotted-initial-properties">
     <template>
-      <vaadin-date-time-picker label="Birth date and time" error-message="error-message" required min="2019-09-01T08:00" max="2019-09-30T22:00">
+      <vaadin-date-time-picker label="Birth date and time"
+          error-message="error-message"
+          required
+          disabled
+          readonly
+          min="2019-09-01T08:00"
+          max="2019-09-30T22:00">
         <vaadin-date-picker slot="date-picker"
           value="2019-09-16"
           placeholder="Pick a date"
@@ -303,16 +311,28 @@
           }
         });
 
-        it('should have initial value for errorMessage property', () => {
+        it('should have initial value for errorMessage', () => {
           expect(dateTimePicker.errorMessage).to.equal('error-message');
           expect(customField.errorMessage).to.equal('error-message');
         });
 
-        it('should have initial value for required property', () => {
+        it('should have initial value for required', () => {
           expect(dateTimePicker.required).to.be.true;
           expect(customField.required).to.be.true;
           expect(datePicker.required).to.be.true;
           expect(timePicker.required).to.be.true;
+        });
+
+        it('should have initial value for disabled', () => {
+          expect(dateTimePicker.disabled).to.be.true;
+          expect(datePicker.disabled).to.be.true;
+          expect(timePicker.disabled).to.be.true;
+        });
+
+        it('should have initial value for readonly', () => {
+          expect(dateTimePicker.readonly).to.be.true;
+          expect(datePicker.readonly).to.be.true;
+          expect(timePicker.readonly).to.be.true;
         });
 
         it('should have initial value for value property', () => {
@@ -362,7 +382,6 @@
           expect(dateTimePicker.label).to.equal('Birth date and time');
           expect(customField.label).to.equal('Birth date and time');
         });
-
 
       });
     });

--- a/test/validation.html
+++ b/test/validation.html
@@ -7,6 +7,7 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-date-time-picker.html">
+  <script src="common.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Propagate "disabled" and "readonly" properties (also) to slotted fields on initialization.