### PR TITLE
docs: add JSDoc for attributes [skip ci]

### DIFF
--- a/src/vaadin-date-time-picker.html
+++ b/src/vaadin-date-time-picker.html
@@ -194,6 +194,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * The error message to display when the input is invalid.
+             * @attr {string} error-message
              */
             errorMessage: String,
 
@@ -263,6 +264,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * A placeholder string for the date field.
+             * @attr {string} date-placeholder
              */
             datePlaceholder: {
               type: String
@@ -270,6 +272,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * A placeholder string for the time field.
+             * @attr {string} time-placeholder
              */
             timePlaceholder: {
               type: String
@@ -299,6 +302,7 @@ This program is available under Apache License Version 2.0, available at https:/
              * Date which should be visible in the date picker overlay when there is no value selected.
              *
              * The same date formats as for the `value` property are supported but without the time part.
+             * @attr {string} initial-position
              */
             initialPosition: String,
 
@@ -306,6 +310,7 @@ This program is available under Apache License Version 2.0, available at https:/
              * Set true to display ISO-8601 week numbers in the calendar. Notice that
              * displaying week numbers is only supported when `i18n.firstDayOfWeek`
              * is 1 (Monday).
+             * @attr {boolean} show-week-numbers
              */
             showWeekNumbers: {
               type: Boolean
@@ -322,6 +327,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Set to true to prevent the overlays from opening automatically.
+             * @attr {boolean} auto-open-disabled
              */
             autoOpenDisabled: Boolean,
 


### PR DESCRIPTION
Connected to vaadin/vaadin-core#257

Note, this is a PR for `1.3` branch. When cherry-picking it to master, we need to also include `helperText` property.