### PR TITLE
test: make sure no initial validation happens for date-time-picker

### DIFF
--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,4 +1,7 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
   "rules": {
     "no-undef": 0,
     "no-unused-vars": 0

--- a/test/common.js
+++ b/test/common.js
@@ -1,2 +1,8 @@
 var ua = navigator.userAgent;
 var ie11 = /Trident/.test(ua);
+
+async function nextRender(element) {
+  return new Promise(resolve => {
+    Polymer.RenderStatus.afterNextRender(element, resolve);
+  });
+}

--- a/test/validation.html
+++ b/test/validation.html
@@ -139,6 +139,40 @@
         });
       });
 
+      describe('initial validation', () => {
+        let validateSpy, dateTimePicker;
+
+        beforeEach(() => {
+          dateTimePicker = document.createElement('vaadin-date-time-picker');
+          validateSpy = sinon.spy(dateTimePicker, 'validate');
+        });
+
+        afterEach(() => {
+          dateTimePicker.remove();
+        });
+
+        it('should not validate by default', async() => {
+          document.body.appendChild(dateTimePicker);
+          await nextRender();
+          expect(validateSpy.called).to.be.false;
+        });
+
+        it('should not validate when the field has an initial value', async() => {
+          dateTimePicker.value = '2020-02-01T02:00';
+          document.body.appendChild(dateTimePicker);
+          await nextRender();
+          expect(validateSpy.called).to.be.false;
+        });
+
+        it('should not validate when the field has an initial value and invalid', async() => {
+          dateTimePicker.value = '2020-02-01T02:00';
+          dateTimePicker.invalid = true;
+          document.body.appendChild(dateTimePicker);
+          await nextRender();
+          expect(validateSpy.called).to.be.false;
+        });
+      });
+
       describe('custom validator', () => {
         beforeEach(() => {
           dateTimePicker = fixture('custom-validation');


### PR DESCRIPTION
Backports web-components#4177 as part of an EoD task


> ## Description
> This PR adds unit tests verifying that no initial validation happens for `date-time-picker`.
> 
> Part of #4150
> 
> ## Type of change
> * [x]  Internal
> 
> ## Checklist
> * [x]  I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
> * [x]  I have added a description following the guideline.
> * [x]  The issue is created in the corresponding repository and I have referenced it.
> * [x]  I have added tests to ensure my change is effective and works as intended.
> * [x]  New and existing tests are passing locally with my change.
> * [x]  I have performed self-review and corrected misspellings.

